### PR TITLE
2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+## v2.3.0
+* Remove default styling for h1/h2/h3/etc. from draftjs scss file– this should be handled by the app, not by draftjs editor
+* Rather than rendering empty divs, we won't render the control blocks if the editor has the readOnly prop passed to it
+
+## v2.0.0
+
 ## v1.0.0 - 2016-08-10
 
 * Refactor decorators to move them out of the main component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synapsestudios/draftjs-editor",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A simple WYSIWYG text editor utilizing Facebook's Draft.js library– customized by Synapse Studios",
   "author": "Synapse Studios",
   "main": "lib/index.js",

--- a/scss/draftjs-editor.scss
+++ b/scss/draftjs-editor.scss
@@ -211,52 +211,6 @@
     display: none;
 }
 
-.DraftJSEditor-editor h1 {
-    font-size: 36px;
-    font-weight: bold;
-}
-
-.DraftJSEditor-editor h2 {
-    font-size: 30px;
-    font-weight: bold;
-}
-
-.DraftJSEditor-editor h3 {
-    font-size: 24px;
-    font-weight: bold;
-}
-
-.DraftJSEditor-editor h4 {
-    font-size: 18px;
-    font-weight: bold;
-}
-
-.DraftJSEditor-editor h5 {
-    font-size: 14px;
-    font-weight: bold;
-}
-
-.DraftJSEditor-editor h6 {
-    font-size: 12px;
-    font-weight: bold;
-}
-
-.DraftJSEditor-editor blockquote {
-    border-left: 5px solid #eee;
-    color: #666;
-    font-family: serif;
-    font-style: italic;
-    margin: 16px 0;
-    padding: 10px 20px;
-}
-
-.DraftJSEditor-editor .public-DraftStyleDefault-pre {
-    background-color: rgba(0, 0, 0, 0.05);
-    font-family: monospace;
-    font-size: 16px;
-    padding: 20px;
-}
-
 .DraftJSEditor-controls {
     font-family: inherit, sans-serif;
     font-size: 14px;

--- a/src/DraftJSEditor.jsx
+++ b/src/DraftJSEditor.jsx
@@ -337,9 +337,9 @@ class DraftJSEditor extends Component {
 
     return (
       <div className="DraftJSEditor-root">
-        {this.renderControls()}
-        {urlInput}
-        {blockInput}
+        {!this.props.readOnly ? this.renderControls() : null}
+        {!this.props.readOnly ? urlInput : null}
+        {!this.props.readOnly ? blockInput : null}
         <div className={className} onClick={this.focus}>
           <Editor
             blockRendererFn={this.renderBlock}


### PR DESCRIPTION
Should fix a problem in our apps with a discrepancy in typography styles when a project doesn't include the draftjs scss file... default typography styles should be the responsibility of the app itself and not this plugin.

Also, we won't render the control blocks if the editor has the `readOnly` prop passed to it.
