### PR TITLE
Spread extra props into Editor component

### DIFF
--- a/src/DraftJSEditor.jsx
+++ b/src/DraftJSEditor.jsx
@@ -365,6 +365,7 @@ class DraftJSEditor extends Component {
             ref="editor"
             spellCheck={this.props.spellCheck}
             stripPastedStyles={this.props.stripPastedStyles}
+            {...this.props}
           />
         </div>
       </div>


### PR DESCRIPTION
#32 

I didn't remove the other `foo={this.props.foo}` places because they have a default setting and I wanted to make sure that that was still honored.

I put the spread below the list to allow for easier overriding if needed by a project--if this is incorrect or not desired, let me know so I can move it above the other attributes/props.